### PR TITLE
Pixel Update Flag on unused serial message bit

### DIFF
--- a/NeoPixelStrip.py
+++ b/NeoPixelStrip.py
@@ -23,7 +23,7 @@ class Strip(object):
         return comm
 
     @staticmethod
-    def _serialize_color(r, g, b, x=False):
+    def _serialize_color(r, g, b, update=True):
         """
         Packs color values into two serial bytes to be read by the arduino.
         
@@ -46,14 +46,14 @@ class Strip(object):
                 print("Color values must be between 0 and 31")  # Make exceptions?
                 return None
 
-        bits = b | (g << 5) | (r << 10) | (x << 15)  # Bitshift values together
+        bits = b | (g << 5) | (r << 10) | (update << 15)  # Bitshift values together
 
         num = struct.pack('H', bits)  # Encode as unsigned long
 
         return num
 
-    def _send_color(self, r=0, g=0, b=0, x=False):
-        ser_color = self._serialize_color(r, g, b, x)
+    def _send_color(self, r=0, g=0, b=0, update=True):
+        ser_color = self._serialize_color(r, g, b, update)
         self.COM.write(ser_color)
         return None
 
@@ -66,14 +66,16 @@ class Strip(object):
             r = led_list[k][0]
             g = led_list[k][1]
             b = led_list[k][2]
-            self._send_color(r,g,b)
+            self._send_color(r, g, b)
 
-    def send_single_color(self, led, r, g, b):
+    def send_single_color(self, led, r=0, g=0, b=0, clobber=False):
         for k in range(self.LEN):
             if k == led:
-                self._send_color(r,g,b)
-            else:
+                self._send_color(r, g, b)
+            elif clobber:
                 self._send_color()
+            else:
+                self._send_color(update=False)
 
     def send_uniform_color(self, r=0, g=0, b=0):
         for k in range(self.LEN):

--- a/init_parmeters.py
+++ b/init_parmeters.py
@@ -1,0 +1,4 @@
+CONFIG_PARAMETERS = {
+    "MaxBrightness": 31,
+    "VolumeColor": [0, 0, 31],
+}

--- a/pyLight.py
+++ b/pyLight.py
@@ -5,12 +5,15 @@ from ctypes import cast, POINTER
 from comtypes import CLSCTX_ALL
 from pycaw.pycaw import AudioUtilities, IAudioEndpointVolume
 from math import ceil
+import init_parmeters
 
 
 class KeyboardController(object):
     def __init__(self, com):
         self.strip = Strip(com)
         keyboard.hook(self.event_hook)
+
+        self.CONFIG_PARAMS = init_parmeters.CONFIG_PARAMETERS
 
         # Get initial interface volume level. Windows Only.
         devices = AudioUtilities.GetSpeakers()
@@ -64,8 +67,8 @@ class KeyboardController(object):
             scalar_volume = self.volume.GetMasterVolumeLevelScalar()
             self.volume_level = self._translate(scalar_volume, 0, 1, 0, self.strip.LEN)
 
-            c = [[0, 0, 0] for _ in range(self.strip.LEN)]
-            c[:self.volume_level] = [[1, 1, 1] for _ in range(self.volume_level)]
+            c = [[0,0,0] for _ in range(self.strip.LEN)]
+            c[:self.volume_level] = [self.CONFIG_PARAMS['VolumeColor'] for _ in range(self.volume_level)]
             self.strip.send_colors(c)
 
     def _translate(self, value, leftMin, leftMax, rightMin, rightMax):

--- a/pyLight.py
+++ b/pyLight.py
@@ -58,9 +58,12 @@ class KeyboardController(object):
             self.strip.send_uniform_color(0, 10, 20)
 
     def number_press(self, event):
+        num = int(event.name)
         if event.event_type == 'down':
-            num = int(event.name)
             self.strip.send_single_color(num, 0, 10, 0)
+        else:
+            self.strip.send_single_color(num)
+
 
     def volume_change(self, event):
         if event.event_type == "down":

--- a/strip_driver/strip_driver.ino
+++ b/strip_driver/strip_driver.ino
@@ -22,15 +22,20 @@ void loop() {
   byte bytes [60]; // Buffer for incoming colors
   uint16_t encoded_rgb;
   uint32_t color;
-  bool extraBit;
+  bool updateBit;  // If HIGH, update the pixel color
+                   // Allows some pixels to be skipped
+                   // on new incoming data buffer.
   
   while (Serial.available() > 59) {
     Serial.readBytes(bytes, 60);
     for (int i=0; i<60; i+=2){
       encoded_rgb = bytes[i] + (bytes[i+1] << 8); // Reconstruct the Short
-      color = decode_rgb(encoded_rgb);
-      extraBit = encoded_rgb >> 15; // unsued bit (future)
-      strip.setPixelColor(i/2, color);
+      updateBit = encoded_rgb >> 15;
+
+      if (updateBit == true){
+        color = decode_rgb(encoded_rgb);
+        strip.setPixelColor(i/2, color);
+      }
     }
     strip.show();
   }


### PR DESCRIPTION
Closes #2

Used the extra unused bit of the serial message to flag individual pixels for update.
Defualts to true in python module `Strip._send_color` method. Inverts logic for the downstream.